### PR TITLE
Feat(#3) 주행 후 피드백 생성 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'org.apache.commons:commons-text:1.11.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/modive/llm/controller/LLMController.java
+++ b/src/main/java/com/modive/llm/controller/LLMController.java
@@ -1,5 +1,6 @@
 package com.modive.llm.controller;
 
+import com.modive.llm.dto.DrivingSummaryRequest;
 import com.modive.llm.dto.PromptRequest;
 import com.modive.llm.service.LLMService;
 import lombok.RequiredArgsConstructor;
@@ -16,9 +17,11 @@ public class LLMController {
 
     @PostMapping("/feedbacks")
     public ResponseEntity<?> getFeedback(@RequestBody PromptRequest request) {
-
-        // TODO: 유저인증 추가
-
         return ResponseEntity.ok().body(llmService.getFeedbacks(request.getMessage()));
+    }
+
+    @PostMapping("/post-feedbacks")
+    public ResponseEntity<?> getPostFeedback(@RequestBody DrivingSummaryRequest request) {
+        return ResponseEntity.ok().body(llmService.getPostFeedback(request));
     }
 }

--- a/src/main/java/com/modive/llm/dto/DrivingSummaryRequest.java
+++ b/src/main/java/com/modive/llm/dto/DrivingSummaryRequest.java
@@ -1,0 +1,27 @@
+package com.modive.llm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrivingSummaryRequest {
+    private int rapidAccelerationDecelerationCount;
+    private int sharpTurnCount;
+    private int overspeedCount;
+    private int idlingTimeMinutes;
+    private int steadySpeedLowRatio;
+    private int steadySpeedMiddleRatio;
+    private int steadySpeedHighRatio;
+    private double averageReactionTimeSeconds;
+    private int laneDepartureCount;
+    private int safeDistanceMaintainMinutes;
+    private int totalDrivingMinutes;
+    private int inactivityTimeMinutes;
+}

--- a/src/main/java/com/modive/llm/dto/DrivingSummaryResponse.java
+++ b/src/main/java/com/modive/llm/dto/DrivingSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.modive.llm.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrivingSummaryResponse {
+    private String rapidAccelerationDecelerationCountFeedback;
+    private String sharpTurnCountFeedback;
+    private String overspeedCountFeedback;
+    private String idlingTimeMinutesFeedback;
+    private String steadySpeedRatioFeedback;
+    private String averageReactionTimeSecondsFeedback;
+    private String laneDepartureCountFeedback;
+    private String safeDistanceMaintainMinutesFeedback;
+    private String totalDrivingMinutesFeedback;
+    private String inactivityTimeMinutesFeedback;
+}

--- a/src/main/java/com/modive/llm/service/GeminiClientService.java
+++ b/src/main/java/com/modive/llm/service/GeminiClientService.java
@@ -1,0 +1,52 @@
+package com.modive.llm.service;
+
+import com.modive.llm.dto.FeedbackRequest;
+import com.modive.llm.dto.FeedbackResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GeminiClientService {
+
+    private final WebClient webClient;
+
+    @Value("${gemini.api.url}")
+    private String apiUrl;
+
+    @Value("${gemini.api.key}")
+    private String geminiApiKey;
+
+    public String callGemini(String prompt) {
+        FeedbackRequest body = FeedbackRequest.builder()
+                .contents(List.of(
+                        FeedbackRequest.Content.builder()
+                                .parts(List.of(
+                                        FeedbackRequest.Part.builder()
+                                                .text(prompt)
+                                                .build()
+                                ))
+                                .build()
+                ))
+                .build();
+
+        FeedbackResponse res = webClient.post()
+                .uri(apiUrl + "?key=" + geminiApiKey)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(FeedbackResponse.class)
+                .block();
+
+        return res.getCandidates()
+                .get(0)
+                .getContent()
+                .getParts()
+                .get(0)
+                .getText();
+    }
+}
+

--- a/src/main/java/com/modive/llm/service/LLMService.java
+++ b/src/main/java/com/modive/llm/service/LLMService.java
@@ -1,54 +1,76 @@
 package com.modive.llm.service;
 
-import com.modive.llm.dto.FeedbackRequest;
-import com.modive.llm.dto.FeedbackResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modive.llm.dto.DrivingSummaryRequest;
+import com.modive.llm.dto.DrivingSummaryResponse;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.text.StringSubstitutor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.List;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class LLMService {
 
-    private final WebClient webClient;
-
-    @Value("${gemini.api.url}")
-    private String apiUrl;
-
-    @Value("${gemini.api.key}")
-    private String geminiApiKey;
+    @Value("classpath:prompts/driving-summary-feedback.txt")
+    private Resource drivingSummaryTmpl;
+    private final ObjectMapper objectMapper;
+    private final GeminiClientService geminiClientService;
 
     public String getFeedbacks(String message) {
+        return geminiClientService.callGemini(message);
+    }
 
-        FeedbackRequest requestBody = FeedbackRequest.builder()
-                .contents(List.of(
-                        FeedbackRequest.Content.builder()
-                                .parts(List.of(
-                                        FeedbackRequest.Part.builder()
-                                                .text(message)
-                                                .build()
-                                ))
-                                .build()
-                ))
-                .build();
+    public DrivingSummaryResponse getPostFeedback(DrivingSummaryRequest req) {
+        String prompt = buildPrompt(req);
+        String rawJson = geminiClientService.callGemini(prompt);
+        return toDto(rawJson);  // JSON → DTO 역직렬화
+    }
 
-        FeedbackResponse response = webClient.post()
-                .uri(apiUrl + "?key=" + geminiApiKey)
-                .bodyValue(requestBody)
-                .retrieve()
-                .bodyToMono(FeedbackResponse.class)
-                .block();
+    private String buildPrompt(DrivingSummaryRequest request) {
+        String template;
+        try (InputStream in = drivingSummaryTmpl.getInputStream()) {
+            template = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("프롬프트 템플릿 읽기 실패", e);
+        }
 
-        String feedback = response.getCandidates()
-                .get(0)
-                .getContent()
-                .getParts()
-                .get(0)
-                .getText();
+        Map<String, Object> values = Map.ofEntries(
+                Map.entry("rapidAccelerationDecelerationCount", request.getRapidAccelerationDecelerationCount()),
+                Map.entry("sharpTurnCount",                    request.getSharpTurnCount()),
+                Map.entry("overspeedCount",                    request.getOverspeedCount()),
+                Map.entry("idlingTimeMinutes",                 request.getIdlingTimeMinutes()),
+                Map.entry("steadySpeedLowRatio",               request.getSteadySpeedLowRatio()),
+                Map.entry("steadySpeedMiddleRatio",            request.getSteadySpeedMiddleRatio()),
+                Map.entry("steadySpeedHighRatio",              request.getSteadySpeedHighRatio()),
+                Map.entry("averageReactionTimeSeconds",        request.getAverageReactionTimeSeconds()),
+                Map.entry("laneDepartureCount",                request.getLaneDepartureCount()),
+                Map.entry("safeDistanceMaintainMinutes",       request.getSafeDistanceMaintainMinutes()),
+                Map.entry("totalDrivingMinutes",               request.getTotalDrivingMinutes()),
+                Map.entry("inactivityTimeMinutes",             request.getInactivityTimeMinutes())
+        );
 
-        return feedback;
+        return new StringSubstitutor(values).replace(template);
+    }
+
+
+    // JSON → DTO
+    private DrivingSummaryResponse toDto(String json) {
+        try {
+            String cleaned = json
+                    .replaceAll("(?s)```json", "")
+                    .replaceAll("(?s)```", "")
+                    .trim();
+
+            return objectMapper.readValue(cleaned, DrivingSummaryResponse.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("Gemini 응답 파싱 실패", e);
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,5 +4,5 @@ spring:
 
 gemini:
   api:
-    url: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent
+    url: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
     key: ${GEMINI_API_KEY}

--- a/src/main/resources/prompts/driving-summary-feedback.txt
+++ b/src/main/resources/prompts/driving-summary-feedback.txt
@@ -1,0 +1,30 @@
+주행 요약 정보:
+- 급가속/급감속 횟수: ${rapidAccelerationDecelerationCount}
+- 급회전 횟수: ${sharpTurnCount}
+- 과속 구간: ${overspeedCount}
+- 공회전 시간(분): ${idlingTimeMinutes}
+- 정속 주행 비율: 저속 ${steadySpeedLowRatio}%, 중속 ${steadySpeedMiddleRatio}%, 고속 ${steadySpeedHighRatio}%
+- 평균 반응속도(초): ${averageReactionTimeSeconds}
+- 차선 이탈 횟수: ${laneDepartureCount}
+- 안전거리 유지 시간(분): ${safeDistanceMaintainMinutes}
+- 총 운전 시간(분): ${totalDrivingMinutes}
+- 미조작 시간(분): ${inactivityTimeMinutes}
+
+위 정보를 바탕으로 각 항목별로 3문장의 피드백을 생성하세요.
+- 정속 주행 비율에 대한 피드백은 저속, 중속, 고속 각각의 비율을 고려하여, 운전 습관을 분석해 주세요.
+  예를 들어 고속 비율이 지나치게 높거나, 저속 정속 주행이 부족할 경우 관련 피드백을 제공해야 합니다.
+
+반드시 다음 형식의 JSON만 반환하십시오:
+
+{
+  "rapidAccelerationDecelerationCountFeedback": "문장",
+  "sharpTurnCountFeedback": "문장",
+  "overspeedCountFeedback": "문장",
+  "idlingTimeMinutesFeedback": "문장",
+  "steadySpeedRatioFeedback": "문장",
+  "averageReactionTimeSecondsFeedback": "문장",
+  "laneDepartureCountFeedback": "문장",
+  "safeDistanceMaintainMinutesFeedback": "문장",
+  "totalDrivingMinutesFeedback": "문장",
+  "inactivityTimeMinutesFeedback": "문장"
+}


### PR DESCRIPTION
## 🔍 이슈

- #3 

---

## 📕 작업 내역

주행 후 피드백 생성 구현
`/llm/post-feedbacks`

- [x] DTO 구조 세팅
- [x] 피드백 생성 API 구현
- [x] GeminiClientService 역할 분리
- [x] 주행 후 주행 데이터 LLM 피드백 생성 테스트

---

## 📸 스크린샷(Optional)

<img width="823" alt="Image" src="https://github.com/user-attachments/assets/368ea0b3-4273-4ffa-a43a-33591540f1e5" />

## 📋 PR 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [x] 파일 혹은 폴더 추가

---

## ⚠️ 추가적으로 설명할 내용

- 프롬프팅하는 driving-summary-feedback.txt 파일은 추후에 구체화 예정입니다.